### PR TITLE
use gitignores found from cwd -> specified subpath

### DIFF
--- a/git_directory_walk.go
+++ b/git_directory_walk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -24,23 +25,76 @@ func (ig *ignores) Match(path string, isDir bool) bool {
 	return false
 }
 
-func WalkDir(root string, fn fs.WalkDirFunc) error {
-	return walk(root, root, fn, &ignores{})
+func WalkDir(cwd, root string, fn fs.WalkDirFunc) error {
+	ignores, err := buildInitialIgnores(cwd, root)
+
+	if err != nil {
+		return err
+	}
+
+	return walk(root, root, fn, ignores)
 }
 
-func walk(root, current string, fn fs.WalkDirFunc, parentIgnores *ignores) error {
-	ignores := &ignores{Rules: append([]*gitignore.IgnoreMatcher{}, parentIgnores.Rules...)}
+func buildInitialIgnores(start, end string) (*ignores, error) {
+	ignores := &ignores{}
 
-	gitignorePath := filepath.Join(current, ".gitignore")
+	startParts := strings.Split(strings.Trim(start, "/"), "/")
+	endParts := strings.Split(strings.Trim(end, "/"), "/")
+
+	// Find where start ends in end
+	i := 0
+	for ; i < len(startParts) && i < len(endParts); i++ {
+		if startParts[i] != endParts[i] {
+			fmt.Println("Start is not a prefix of end")
+			return ignores, fmt.Errorf("start path %s is not a prefix of end path %s", start, end)
+		}
+	}
+
+	// Start from startParts and add one segment at a time
+	for j := len(startParts); j <= len(endParts); j++ {
+		p := "/" + path.Join(endParts[:j]...)
+
+		rule, err := getGitIgnore(p)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to get gitignore for path %s: %w", p, err)
+		}
+
+		if rule != nil {
+			ignores.Rules = append(ignores.Rules, rule)
+		}
+	}
+
+	return ignores, nil
+}
+
+func getGitIgnore(path string) (*gitignore.IgnoreMatcher, error) {
+	gitignorePath := filepath.Join(path, ".gitignore")
 
 	if _, err := os.Stat(gitignorePath); err == nil {
 		rule, err := gitignore.NewGitIgnore(gitignorePath)
 
 		if err != nil {
-			return fmt.Errorf("failed to parse %s: %w", gitignorePath, err)
+			return nil, fmt.Errorf("failed to parse %s: %w", gitignorePath, err)
 		}
 
-		ignores.Rules = append(ignores.Rules, &rule)
+		return &rule, nil
+	}
+
+	return nil, nil
+}
+
+func walk(root, current string, fn fs.WalkDirFunc, parentIgnores *ignores) error {
+	ignores := &ignores{Rules: append([]*gitignore.IgnoreMatcher{}, parentIgnores.Rules...)}
+
+	rule, err := getGitIgnore(current)
+
+	if err != nil {
+		return err
+	}
+
+	if rule != nil {
+		ignores.Rules = append(ignores.Rules, rule)
 	}
 
 	entries, err := os.ReadDir(current)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"strings"
 	"syscall"
 
@@ -24,7 +25,18 @@ var RootCmd = &cobra.Command{
 
 		root = strings.TrimPrefix(root, "./")
 
-		rootCommand(root)
+		dir, err := os.Getwd()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to get current working directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		if !strings.HasPrefix(root, "/") {
+			root = path.Join(dir, root)
+		}
+
+		rootCommand(dir, root)
 	},
 }
 
@@ -34,10 +46,10 @@ func main() {
 	}
 }
 
-func rootCommand(root string) {
+func rootCommand(cwd, root string) {
 	files := []string{}
 
-	err := WalkDir(root, func(path string, d os.DirEntry, err error) error {
+	err := WalkDir(cwd, root, func(path string, d os.DirEntry, err error) error {
 		if !d.IsDir() {
 			files = append(files, path)
 		}


### PR DESCRIPTION
previously, if you had a .gitignore in the cwd but specified a subpath like `./a/b` then it was not being applied 